### PR TITLE
Improve GitHub Actions workflow

### DIFF
--- a/.github/workflows/convert_markdown.yml
+++ b/.github/workflows/convert_markdown.yml
@@ -6,19 +6,25 @@ on:
       - master
       - gh-pages
 
-# Pages デプロイで必要
+# 同一ブランチのデプロイ競合を防止
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  contents: write        # gh-pages のコミット用
-  pages: write           # actions/deploy-pages 用
-  id-token: write        # actions/deploy-pages 用
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-# ------------------------------------------------------------------
-# 1) master ブランチ = 本番環境へ反映
-# ------------------------------------------------------------------
+  # ------------------------------------------------------------------
+  # 1) master ブランチ = 本番環境へ反映
+  # ------------------------------------------------------------------
   prod-deploy:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
@@ -37,17 +43,16 @@ jobs:
               -o UserKnownHostsFile=/dev/null \
               "cd /var/www/html/pws/ && git pull origin master"
 
-# ------------------------------------------------------------------
-# 2) gh-pages ブランチ = GitHub Pages 用
-# ------------------------------------------------------------------
+  # ------------------------------------------------------------------
+  # 2) gh-pages ブランチ = GitHub Pages 用（artifact方式）
+  # ------------------------------------------------------------------
   build-pages:
     if: github.ref == 'refs/heads/gh-pages'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
 
-      # （任意）更新差分の確認
       - name: Show last commit
         run: git --no-pager log -1 --stat
 
@@ -57,29 +62,19 @@ jobs:
       - name: Build HTML by make.bash
         run: bash make.bash
 
-      # HTML を gh-pages ブランチにコミット（必要なら）
-      - name: Commit & push built files
-        run: |
-          if ! git diff --quiet; then
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add .
-            git commit -m 'Generate HTML [skip ci]'
-            git push origin gh-pages
-          fi
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
 
-      # GitHub Pages へ渡すアーティファクトをアップロード
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # make.bash の出力先に合わせて変更
-          path: ./ # 例：./public や ./docs など
+          # make.bash の成果物ディレクトリに合わせてください（例: ./html や ./public 等）
+          path: ./
 
   deploy-pages:
     needs: build-pages
-    # gh-pages ブランチのみ実行
     if: github.ref == 'refs/heads/gh-pages'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- `ubuntu-latest` → `ubuntu-24.04` に固定（3ジョブすべて）
- `concurrency` セクション追加（同一ブランチのデプロイ競合防止）
- `permissions` スコープ縮小（`contents: write` → `contents: read`）
- 「Commit & push built files」ステップ削除（不要なHTMLコミットを廃止）
- `actions/configure-pages@v5` ステップ追加

## Test plan
- [ ] gh-pages ブランチへの push で GitHub Pages デプロイが正常に動作すること
- [ ] master ブランチへの push で本番サーバーへのデプロイが正常に動作すること

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)