### PR TITLE
ppsd: GFM互換のMarkdown変換エンジンに切り替え

### DIFF
--- a/ppsd/html/index.html
+++ b/ppsd/html/index.html
@@ -1,102 +1,98 @@
 <!DOCTYPE html>
 <html lang="ja" dir="ltr">
-<head>
-  <meta name="generator" content=
-  "HTML Tidy for HTML5 for Linux version 5.6.0">
-  <meta http-equiv="Content-Type" content=
-  "text/html; charset=utf-8">
-  <script src="jquery.min.js" type="text/javascript"></script>
-  <title>データ合成技術評価委員会</title>
-</head>
-<body style="margin-top:40px">
-  <link rel="stylesheet" type="text/css" href="./style.css">
-  <div id="menu-wrap" class="fixed">
-    <ul id="menu">
-      <li>
-        <a href="./index.html">Top</a>
-      </li>
-      <li>
-        <a href="../index.html">About PWS</a>
-      </li>
-      <li>
-        <a href="https://www.iwsec.org/pws">Past PWS</a>
-      </li>
-    </ul>
-  </div>
-  <div id="page">
-    <!-- contents start -->
-    <h1 id="_1">データ合成技術評価委員会</h1>
-    <h2 id="_2">データ合成技術評価委員会について</h2>
-    <p>
-    パーソナルデータを保護しつつ利活用するための技術としてデータ合成が注目されており、諸外国では実用化も進んでいます。データ合成により、元のパーソナルデータから「合成データ」を作成できます。合成データは一般に、元のデータの統計的特徴をなるべく維持した架空の人物のデータとなり、有用性の高い匿名化データとして利活用が期待されています。しかし合成データの匿名性はデータ合成の手法に依存し、国内外でも合成データを匿名化データと認定する基準は定まっていません。そのため、匿名性の低い合成データの利用によるプライバシー侵害や、合成データを利用したくても基準が不明確のため利用できないといった事態が危惧されます。そこで情報処理学会
-    コンピュータセキュリティ研究会 PWS(Privacy
-    Workshop)組織委員会は、データ合成技術の有識者および健全な合成データの利活用促進を目指す研究者・実務者からなるデータ合成技術評価委員会を立ち上げ、2023年4月から活動を開始しました。</p>
-    <h2 id="_3">活動内容</h2>
-    <p>
-    健全な合成データの利活用促進に向け、既存のデータ合成手法の匿名性を評価するとともに、合成データの匿名性の基準の作成を目指します。具体的な検討結果や評価結果は本ホームページにて随時公開していく予定です。
-    2024年10月22日から25日に開催される「コンピュータセキュリティシンポジウム2024（CSS2024）」にて、現在までの活動内容を報告いたします。</p>
-    <h2 id="whats-new">What's new</h2>
-    <ul>
-      <li>2024/10/23(水)
-      CSS2024のPWS企画セッションにて、講演「安全かつ有用な合成データの作成に関する新たな動向」を実施しました</li>
-    </ul>
-    <h2>目次</h2>
-    <div class="toc">
-      <ul>
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <title>データ合成技術評価委員会</title>
+  </head>
+  <body style="margin-top:40px">
+    <link rel="stylesheet" type="text/css" href="./style.css">
+    <div id="menu-wrap" class="fixed">
+      <ul id="menu">
         <li>
-          <a href="#_2">データ合成技術評価委員会について</a>
+          <a href="./index.html">Top</a>
         </li>
         <li>
-          <a href="#_3">活動内容</a>
+          <a href="../index.html">About PWS</a>
         </li>
         <li>
-          <a href="#whats-new">What's new</a>
-        </li>
-        <li>
-          <a href="#_4">メンバー</a>
-          <ul>
-            <li>
-              <a href="#_5">関連サイト</a>
-            </li>
-          </ul>
+          <a href="https://www.iwsec.org/pws">Past PWS</a>
         </li>
       </ul>
     </div>
-    <h2 id="_4">メンバー</h2>
-    <dl>
-      <dt>委員長</dt>
-      <dd>千田浩司 (群馬大学)</dd>
-      <dt>委員</dt>
-      <dd>荒井ひろみ (理化学研究所)、 伊藤伸介 (中央大学)、 牛田芽生恵 (富士通)、 菊池浩明 (明治大学)、
-      木村映善 (愛媛大学)、 黒政敦史 (データ社会推進協議会)、 清雄一 (電気通信大学)、 高木理 (群馬大学)、 高橋翼
-      (Acompany)、 竹之内隆夫 (Acompany)、 寺田雅之 (NTTドコモ)、 中村優一 (ソフトバンク)、
-      波多野卓磨 (日鉄ソリューションズ)、 東貴範 (TOPPANデジタル)、 前田若菜 (LINEヤフー)、 三浦尭之
-      (NTT)、 美馬正司 (日立コンサルティング／慶応義塾大学)、 南和宏 (統計数理研究所)、 村上隆夫
-      (統計数理研究所)、 森毅 (日本総合研究所)</dd>
-    </dl>
-    <h3 id="_5">関連サイト</h3>
-    <ul>
-      <li>
-        <a href="https://www.iwsec.org/pws/">プライバシーワークショップ</a>
-      </li>
-      <li>
-        <a href=
-        "https://www.iwsec.org/css/2024/">コンピュータセキュリティシンポジウム2024（CSS2024）</a>
-      </li>
-      <li>
-        <a href="https://www.iwsec.org/csec/">（一社）情報処理学会
-        コンピュータセキュリティ研究会</a>
-      </li>
-      <li>
-        <a href="https://www.ipsj.or.jp/">（一社）情報処理学会</a>
-      </li>
-    </ul>
-    <div id="footer">
-      <p id="copyright">Copyright 2023-2024 (一社)情報処理学会
-      コンピュータセキュリティ研究会 PWS組織委員会 データ合成技術評価委員会 All rights reserved</p>
-    </div><!-- contents end -->
-  </div>
-  <script type="text/javascript">
+    <div id="page">
+
+<!-- contents start -->
+<h1>データ合成技術評価委員会</h1>
+<h2 id="データ合成技術評価委員会について">データ合成技術評価委員会について</h2>
+<p>パーソナルデータを保護しつつ利活用するための技術としてデータ合成が注目されており、諸外国では実用化も進んでいます。データ合成により、元のパーソナルデータから「合成データ」を作成できます。合成データは一般に、元のデータの統計的特徴をなるべく維持した架空の人物のデータとなり、有用性の高い匿名化データとして利活用が期待されています。しかし合成データの匿名性はデータ合成の手法に依存し、国内外でも合成データを匿名化データと認定する基準は定まっていません。そのため、匿名性の低い合成データの利用によるプライバシー侵害や、合成データを利用したくても基準が不明確のため利用できないといった事態が危惧されます。そこで情報処理学会 コンピュータセキュリティ研究会 PWS(Privacy Workshop)組織委員会は、データ合成技術の有識者および健全な合成データの利活用促進を目指す研究者・実務者からなるデータ合成技術評価委員会を立ち上げ、2023年4月から活動を開始しました。</p>
+<h2 id="活動内容">活動内容</h2>
+<p>健全な合成データの利活用促進に向け、既存のデータ合成手法の匿名性を評価するとともに、合成データの匿名性の基準の作成を目指します。具体的な検討結果や評価結果は本ホームページにて随時公開していく予定です。
+2024年10月22日から25日に開催される「コンピュータセキュリティシンポジウム2024（CSS2024）」にて、現在までの活動内容を報告いたします。</p>
+<h2 id="whats-new">What's new</h2>
+<ul>
+<li>2024/10/23(水) CSS2024のPWS企画セッションにて、講演「安全かつ有用な合成データの作成に関する新たな動向」を実施しました</li>
+</ul>
+
+<h2>目次</h2>
+<div class="toc">
+<ul>
+<li><a href="#データ合成技術評価委員会について">データ合成技術評価委員会について</a>
+</li>
+<li><a href="#活動内容">活動内容</a>
+</li>
+<li><a href="#whats-new">What's new</a>
+</li>
+<li><a href="#メンバー">メンバー</a>
+<ul>
+<li><a href="#関連サイト">関連サイト</a>
+</li>
+</ul>
+</li>
+</ul>
+</div><h2 id="メンバー">メンバー</h2>
+<dl>
+ <dt>委員長</dt>
+  <dd>千田浩司 (群馬大学)</dd>
+ <dt>委員</dt>
+  <dd>
+   荒井ひろみ (理化学研究所)、
+   伊藤伸介 (中央大学)、
+   牛田芽生恵 (富士通)、
+   菊池浩明 (明治大学)、
+   木村映善 (愛媛大学)、
+   黒政敦史 (データ社会推進協議会)、
+   清雄一 (電気通信大学)、
+   高木理 (群馬大学)、
+   高橋翼 (Acompany)、
+   竹之内隆夫 (Acompany)、
+   寺田雅之 (NTTドコモ)、
+   中村優一 (ソフトバンク)、
+   波多野卓磨 (日鉄ソリューションズ)、
+   東貴範 (TOPPANデジタル)、
+   前田若菜 (LINEヤフー)、
+   三浦尭之 (NTT)、
+   美馬正司 (日立コンサルティング／慶応義塾大学)、
+   南和宏 (統計数理研究所)、
+   村上隆夫 (統計数理研究所)、
+   森毅 (日本総合研究所)
+  </dd>
+</dl>
+<h3 id="関連サイト">関連サイト</h3>
+<ul>
+<li><a href="https://www.iwsec.org/pws/">プライバシーワークショップ</a></li>
+<li><a href="https://www.iwsec.org/css/2024/">コンピュータセキュリティシンポジウム2024（CSS2024）</a></li>
+<li><a href="https://www.iwsec.org/csec/">（一社）情報処理学会 コンピュータセキュリティ研究会</a></li>
+<li><a href="https://www.ipsj.or.jp/">（一社）情報処理学会</a></li>
+</ul>
+<div id="footer">
+ <p id="copyright">Copyright 2023-2024 (一社)情報処理学会 コンピュータセキュリティ研究会 PWS組織委員会 データ合成技術評価委員会 All rights reserved</p>
+</div>
+
+<!-- contents end -->
+     </div>
+      <script type="text/javascript">
         $(function(){
           var box    = $("#menu-wrap");
           var boxTop = box.offset().top;
@@ -110,6 +106,7 @@
            }
           });
         });
-  </script>
-</body>
+      </script>
+  </body>
 </html>
+

--- a/ppsd/index.html
+++ b/ppsd/index.html
@@ -1,102 +1,98 @@
 <!DOCTYPE html>
 <html lang="ja" dir="ltr">
-<head>
-  <meta name="generator" content=
-  "HTML Tidy for HTML5 for Linux version 5.6.0">
-  <meta http-equiv="Content-Type" content=
-  "text/html; charset=utf-8">
-  <script src="jquery.min.js" type="text/javascript"></script>
-  <title>データ合成技術評価委員会</title>
-</head>
-<body style="margin-top:40px">
-  <link rel="stylesheet" type="text/css" href="./style.css">
-  <div id="menu-wrap" class="fixed">
-    <ul id="menu">
-      <li>
-        <a href="./index.html">Top</a>
-      </li>
-      <li>
-        <a href="../index.html">About PWS</a>
-      </li>
-      <li>
-        <a href="https://www.iwsec.org/pws">Past PWS</a>
-      </li>
-    </ul>
-  </div>
-  <div id="page">
-    <!-- contents start -->
-    <h1 id="_1">データ合成技術評価委員会</h1>
-    <h2 id="_2">データ合成技術評価委員会について</h2>
-    <p>
-    パーソナルデータを保護しつつ利活用するための技術としてデータ合成が注目されており、諸外国では実用化も進んでいます。データ合成により、元のパーソナルデータから「合成データ」を作成できます。合成データは一般に、元のデータの統計的特徴をなるべく維持した架空の人物のデータとなり、有用性の高い匿名化データとして利活用が期待されています。しかし合成データの匿名性はデータ合成の手法に依存し、国内外でも合成データを匿名化データと認定する基準は定まっていません。そのため、匿名性の低い合成データの利用によるプライバシー侵害や、合成データを利用したくても基準が不明確のため利用できないといった事態が危惧されます。そこで情報処理学会
-    コンピュータセキュリティ研究会 PWS(Privacy
-    Workshop)組織委員会は、データ合成技術の有識者および健全な合成データの利活用促進を目指す研究者・実務者からなるデータ合成技術評価委員会を立ち上げ、2023年4月から活動を開始しました。</p>
-    <h2 id="_3">活動内容</h2>
-    <p>
-    健全な合成データの利活用促進に向け、既存のデータ合成手法の匿名性を評価するとともに、合成データの匿名性の基準の作成を目指します。具体的な検討結果や評価結果は本ホームページにて随時公開していく予定です。
-    2024年10月22日から25日に開催される「コンピュータセキュリティシンポジウム2024（CSS2024）」にて、現在までの活動内容を報告いたします。</p>
-    <h2 id="whats-new">What's new</h2>
-    <ul>
-      <li>2024/10/23(水)
-      CSS2024のPWS企画セッションにて、講演「安全かつ有用な合成データの作成に関する新たな動向」を実施しました</li>
-    </ul>
-    <h2>目次</h2>
-    <div class="toc">
-      <ul>
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <title>データ合成技術評価委員会</title>
+  </head>
+  <body style="margin-top:40px">
+    <link rel="stylesheet" type="text/css" href="./style.css">
+    <div id="menu-wrap" class="fixed">
+      <ul id="menu">
         <li>
-          <a href="#_2">データ合成技術評価委員会について</a>
+          <a href="./index.html">Top</a>
         </li>
         <li>
-          <a href="#_3">活動内容</a>
+          <a href="../index.html">About PWS</a>
         </li>
         <li>
-          <a href="#whats-new">What's new</a>
-        </li>
-        <li>
-          <a href="#_4">メンバー</a>
-          <ul>
-            <li>
-              <a href="#_5">関連サイト</a>
-            </li>
-          </ul>
+          <a href="https://www.iwsec.org/pws">Past PWS</a>
         </li>
       </ul>
     </div>
-    <h2 id="_4">メンバー</h2>
-    <dl>
-      <dt>委員長</dt>
-      <dd>千田浩司 (群馬大学)</dd>
-      <dt>委員</dt>
-      <dd>荒井ひろみ (理化学研究所)、 伊藤伸介 (中央大学)、 牛田芽生恵 (富士通)、 菊池浩明 (明治大学)、
-      木村映善 (愛媛大学)、 黒政敦史 (データ社会推進協議会)、 清雄一 (電気通信大学)、 高木理 (群馬大学)、 高橋翼
-      (Acompany)、 竹之内隆夫 (Acompany)、 寺田雅之 (NTTドコモ)、 中村優一 (ソフトバンク)、
-      波多野卓磨 (日鉄ソリューションズ)、 東貴範 (TOPPANデジタル)、 前田若菜 (LINEヤフー)、 三浦尭之
-      (NTT)、 美馬正司 (日立コンサルティング／慶応義塾大学)、 南和宏 (統計数理研究所)、 村上隆夫
-      (統計数理研究所)、 森毅 (日本総合研究所)</dd>
-    </dl>
-    <h3 id="_5">関連サイト</h3>
-    <ul>
-      <li>
-        <a href="https://www.iwsec.org/pws/">プライバシーワークショップ</a>
-      </li>
-      <li>
-        <a href=
-        "https://www.iwsec.org/css/2024/">コンピュータセキュリティシンポジウム2024（CSS2024）</a>
-      </li>
-      <li>
-        <a href="https://www.iwsec.org/csec/">（一社）情報処理学会
-        コンピュータセキュリティ研究会</a>
-      </li>
-      <li>
-        <a href="https://www.ipsj.or.jp/">（一社）情報処理学会</a>
-      </li>
-    </ul>
-    <div id="footer">
-      <p id="copyright">Copyright 2023-2024 (一社)情報処理学会
-      コンピュータセキュリティ研究会 PWS組織委員会 データ合成技術評価委員会 All rights reserved</p>
-    </div><!-- contents end -->
-  </div>
-  <script type="text/javascript">
+    <div id="page">
+
+<!-- contents start -->
+<h1>データ合成技術評価委員会</h1>
+<h2 id="データ合成技術評価委員会について">データ合成技術評価委員会について</h2>
+<p>パーソナルデータを保護しつつ利活用するための技術としてデータ合成が注目されており、諸外国では実用化も進んでいます。データ合成により、元のパーソナルデータから「合成データ」を作成できます。合成データは一般に、元のデータの統計的特徴をなるべく維持した架空の人物のデータとなり、有用性の高い匿名化データとして利活用が期待されています。しかし合成データの匿名性はデータ合成の手法に依存し、国内外でも合成データを匿名化データと認定する基準は定まっていません。そのため、匿名性の低い合成データの利用によるプライバシー侵害や、合成データを利用したくても基準が不明確のため利用できないといった事態が危惧されます。そこで情報処理学会 コンピュータセキュリティ研究会 PWS(Privacy Workshop)組織委員会は、データ合成技術の有識者および健全な合成データの利活用促進を目指す研究者・実務者からなるデータ合成技術評価委員会を立ち上げ、2023年4月から活動を開始しました。</p>
+<h2 id="活動内容">活動内容</h2>
+<p>健全な合成データの利活用促進に向け、既存のデータ合成手法の匿名性を評価するとともに、合成データの匿名性の基準の作成を目指します。具体的な検討結果や評価結果は本ホームページにて随時公開していく予定です。
+2024年10月22日から25日に開催される「コンピュータセキュリティシンポジウム2024（CSS2024）」にて、現在までの活動内容を報告いたします。</p>
+<h2 id="whats-new">What's new</h2>
+<ul>
+<li>2024/10/23(水) CSS2024のPWS企画セッションにて、講演「安全かつ有用な合成データの作成に関する新たな動向」を実施しました</li>
+</ul>
+
+<h2>目次</h2>
+<div class="toc">
+<ul>
+<li><a href="#データ合成技術評価委員会について">データ合成技術評価委員会について</a>
+</li>
+<li><a href="#活動内容">活動内容</a>
+</li>
+<li><a href="#whats-new">What's new</a>
+</li>
+<li><a href="#メンバー">メンバー</a>
+<ul>
+<li><a href="#関連サイト">関連サイト</a>
+</li>
+</ul>
+</li>
+</ul>
+</div><h2 id="メンバー">メンバー</h2>
+<dl>
+ <dt>委員長</dt>
+  <dd>千田浩司 (群馬大学)</dd>
+ <dt>委員</dt>
+  <dd>
+   荒井ひろみ (理化学研究所)、
+   伊藤伸介 (中央大学)、
+   牛田芽生恵 (富士通)、
+   菊池浩明 (明治大学)、
+   木村映善 (愛媛大学)、
+   黒政敦史 (データ社会推進協議会)、
+   清雄一 (電気通信大学)、
+   高木理 (群馬大学)、
+   高橋翼 (Acompany)、
+   竹之内隆夫 (Acompany)、
+   寺田雅之 (NTTドコモ)、
+   中村優一 (ソフトバンク)、
+   波多野卓磨 (日鉄ソリューションズ)、
+   東貴範 (TOPPANデジタル)、
+   前田若菜 (LINEヤフー)、
+   三浦尭之 (NTT)、
+   美馬正司 (日立コンサルティング／慶応義塾大学)、
+   南和宏 (統計数理研究所)、
+   村上隆夫 (統計数理研究所)、
+   森毅 (日本総合研究所)
+  </dd>
+</dl>
+<h3 id="関連サイト">関連サイト</h3>
+<ul>
+<li><a href="https://www.iwsec.org/pws/">プライバシーワークショップ</a></li>
+<li><a href="https://www.iwsec.org/css/2024/">コンピュータセキュリティシンポジウム2024（CSS2024）</a></li>
+<li><a href="https://www.iwsec.org/csec/">（一社）情報処理学会 コンピュータセキュリティ研究会</a></li>
+<li><a href="https://www.ipsj.or.jp/">（一社）情報処理学会</a></li>
+</ul>
+<div id="footer">
+ <p id="copyright">Copyright 2023-2024 (一社)情報処理学会 コンピュータセキュリティ研究会 PWS組織委員会 データ合成技術評価委員会 All rights reserved</p>
+</div>
+
+<!-- contents end -->
+     </div>
+      <script type="text/javascript">
         $(function(){
           var box    = $("#menu-wrap");
           var boxTop = box.offset().top;
@@ -110,6 +106,7 @@
            }
           });
         });
-  </script>
-</body>
+      </script>
+  </body>
 </html>
+

--- a/ppsd/scripts/make.py
+++ b/ppsd/scripts/make.py
@@ -49,13 +49,6 @@ def main() -> int:
             check=True,
         )
 
-        tidy_result = subprocess.run(
-            ["tidy", "-quiet", "-indent", "-utf8", "-m", str(html)],
-            check=False,
-        )
-        if tidy_result.returncode != 0:
-            print("[WARN] tidy reported issues; continuing")
-
         html.chmod(0o660)
 
         dest = public_dir / f"{base}.html"

--- a/ppsd/scripts/pandoc.py
+++ b/ppsd/scripts/pandoc.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
-from markdown import Markdown
+import re
+import unicodedata
+
+from markdown_it import MarkdownIt
+from mdit_py_plugins.footnote import footnote_plugin
+from mdit_py_plugins.tasklists import tasklists_plugin
 
 
 DEFAULT_TITLE = "PWS"
@@ -38,15 +43,107 @@ def build_header(script_dir: Path, base: str, title: str) -> str:
     return f"{header1}    <title>{title}</title>\n{header2}"
 
 
+def _slugify(text: str) -> str:
+    """Generate a slug suitable for use as an HTML id attribute."""
+    text = unicodedata.normalize("NFC", text)
+    text = text.lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    text = re.sub(r"[\s]+", "-", text).strip("-")
+    return text
+
+
+def _collect_headings(tokens: list) -> list[tuple[int, str, str]]:
+    """Walk markdown-it tokens and return (level, id, text) for h2-h6."""
+    headings: list[tuple[int, str, str]] = []
+    slug_counts: dict[str, int] = {}
+    counter = 0
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.type == "heading_open":
+            level = int(tok.tag[1])  # e.g. "h2" -> 2
+            # Collect inline text from the next token
+            inline_tok = tokens[i + 1] if i + 1 < len(tokens) else None
+            text = ""
+            if inline_tok and inline_tok.children:
+                text = "".join(
+                    child.content for child in inline_tok.children
+                    if child.type in ("text", "code_inline")
+                )
+            if level >= 2:
+                slug = _slugify(text)
+                if not slug:
+                    counter += 1
+                    slug = f"_{counter}"
+                else:
+                    count = slug_counts.get(slug, 0)
+                    if count:
+                        slug = f"{slug}-{count}"
+                    slug_counts[slug.split("-")[0] if "-" in slug else slug] = count + 1
+                headings.append((level, slug, text))
+                # Inject id into the heading_open token
+                tok.attrSet("id", slug)
+        i += 1
+    return headings
+
+
+def _build_toc_html(headings: list[tuple[int, str, str]]) -> str:
+    """Build a nested TOC HTML string matching the old Markdown TOC format."""
+    if not headings:
+        return ""
+    lines: list[str] = ['<div class="toc">', "<ul>"]
+    base_level = headings[0][0]
+    prev_level = base_level
+
+    for level, slug, text in headings:
+        if level > prev_level:
+            # Open nested lists
+            for _ in range(level - prev_level):
+                lines.append("<ul>")
+        elif level < prev_level:
+            # Close nested lists and their parent items
+            for _ in range(prev_level - level):
+                lines.append("</li>")
+                lines.append("</ul>")
+            # Close the sibling item at the current level
+            lines.append("</li>")
+        else:
+            # Same level — close previous item
+            if lines[-1] != "<ul>":
+                lines.append("</li>")
+        lines.append(f'<li><a href="#{slug}">{text}</a>')
+        prev_level = level
+
+    # Close all remaining open tags
+    for _ in range(prev_level - base_level):
+        lines.append("</li>")
+        lines.append("</ul>")
+    lines.append("</li>")
+    lines.append("</ul>")
+    lines.append("</div>")
+    return "\n".join(lines)
+
+
 def build_body(md_text: str) -> tuple[str, str]:
-    md = Markdown(
-        extensions=["tables", "footnotes", "toc", "fenced_code"],
-        extension_configs={
-            "toc": {"toc_depth": "2-6"},
-        },
-    )
-    html_body = md.convert(md_text)
-    toc_html = md.toc or ""
+    md = MarkdownIt("commonmark", {"html": True}).enable(["table", "strikethrough"])
+    footnote_plugin(md)
+    tasklists_plugin(md)
+
+    tokens = md.parse(md_text)
+    headings = _collect_headings(tokens)
+    toc_html = _build_toc_html(headings)
+
+    html_body = md.render(md_text)
+    # Re-render with the id attributes injected into heading tokens
+    # Since render() re-parses, we need to render from tokens directly
+    # markdown-it-py doesn't have a render_from_tokens, so we re-inject
+    # ids by post-processing the HTML
+    for level, slug, text in headings:
+        # Add id to the first matching heading tag without an id
+        pattern = f"<h{level}>"
+        replacement = f'<h{level} id="{slug}">'
+        html_body = html_body.replace(pattern, replacement, 1)
+
     if "<li>" not in toc_html:
         toc_html = ""
     return toc_html, html_body

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Markdown>=3.5
+markdown-it-py>=3.0
+mdit-py-plugins>=0.4

--- a/tests/test_ppsd_pandoc.py
+++ b/tests/test_ppsd_pandoc.py
@@ -1,0 +1,86 @@
+"""Tests for ppsd/scripts/pandoc.py (GFM-compatible engine)."""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "ppsd" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+# Force reload to avoid using cached 2026/scripts/pandoc
+if "pandoc" in sys.modules:
+    del sys.modules["pandoc"]
+import pandoc as ppsd_pandoc  # noqa: E402
+
+
+class TestBuildBodyGfm:
+    def test_basic_conversion(self):
+        toc, html = ppsd_pandoc.build_body("# Hello\n\nParagraph\n")
+        assert "<p>Paragraph</p>" in html
+
+    def test_table_conversion(self):
+        md = "| A | B |\n|---|---|\n| 1 | 2 |\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert "<table>" in html
+        assert "<td>1</td>" in html
+
+    def test_fenced_code(self):
+        md = "```python\nprint('hello')\n```\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert "<code" in html
+        assert "print" in html
+
+    def test_footnote(self):
+        md = "Text[^1]\n\n[^1]: Footnote content\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert "Footnote content" in html
+
+    def test_strikethrough(self):
+        md = "~~deleted text~~\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert "<s>" in html or "<del>" in html
+        assert "deleted text" in html
+
+    def test_raw_html_preserved(self):
+        md = "<dl>\n<dt>Key</dt>\n<dd>Value</dd>\n</dl>\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert "<dl>" in html
+        assert "<dt>Key</dt>" in html
+        assert "<dd>Value</dd>" in html
+
+    def test_dash_list(self):
+        md = "- item1\n- item2\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert "<li>" in html
+        assert "item1" in html
+
+    def test_toc_generated_with_sections(self):
+        md = "# Title\n## Sec1\ntext\n## Sec2\ntext\n"
+        toc, _ = ppsd_pandoc.build_body(md)
+        assert "<li>" in toc
+        assert "Sec1" in toc
+        assert "Sec2" in toc
+
+    def test_toc_empty_without_sections(self):
+        md = "# Title only\nsome text\n"
+        toc, _ = ppsd_pandoc.build_body(md)
+        assert toc == ""
+
+    def test_heading_ids_generated(self):
+        md = "# Title\n## Section One\ntext\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert 'id="section-one"' in html
+
+    def test_japanese_heading_ids(self):
+        md = "# タイトル\n## セクション\ntext\n"
+        _, html = ppsd_pandoc.build_body(md)
+        assert 'id="セクション"' in html
+
+    def test_toc_structure(self):
+        md = "# Title\n## A\ntext\n### B\ntext\n## C\ntext\n"
+        toc, _ = ppsd_pandoc.build_body(md)
+        assert '<div class="toc">' in toc
+        assert "<ul>" in toc
+        assert "</ul>" in toc


### PR DESCRIPTION
## Summary
- ppsdディレクトリのMarkdown→HTML変換エンジンをPython `markdown` から `markdown-it-py` に変更し、GitHub Flavored Markdown互換に
- `tidy` 後処理を削除（HTML構造の崩れの原因だった）
- 打ち消し線(`~~`)、タスクリスト(`- [ ]`)、生HTML保持など、GitHubプレビューとの差異を解消

Closes #678

## 変更ファイル
- `ppsd/scripts/pandoc.py` — 変換エンジンを `markdown-it-py` に切り替え
- `ppsd/scripts/make.py` — `tidy` 後処理を削除
- `requirements.txt` — `markdown-it-py`, `mdit-py-plugins` を追加
- `tests/test_ppsd_pandoc.py` — GFM固有機能のテストを新規追加

## Test plan
- [x] 全43テストパス（既存31 + 新規12）
- [x] ppsdビルド成功
- [x] 生成HTMLで `<dl>` タグが保持されていることを確認
- [x] 2026ディレクトリのビルドに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)