### PR TITLE
ppsd: make.pyで画像をpublic_dir/Imagesにもrsyncするよう修正

### DIFF
--- a/ppsd/scripts/make.py
+++ b/ppsd/scripts/make.py
@@ -57,17 +57,18 @@ def main() -> int:
 
     images_dir = md_dir / "Images"
     if images_dir.is_dir():
-        subprocess.run(
-            [
-                "rsync",
-                "-rt",
-                "--delete",
-                "--chmod=Du=rwx,Dg=rwx,Fu=rw,Fg=rw",
-                f"{images_dir}/",
-                f"{(html_dir / 'Images')}/",
-            ],
-            check=True,
-        )
+        for dest_images in [html_dir / "Images", public_dir / "Images"]:
+            subprocess.run(
+                [
+                    "rsync",
+                    "-rt",
+                    "--delete",
+                    "--chmod=Du=rwx,Dg=rwx,Fu=rw,Fg=rw",
+                    f"{images_dir}/",
+                    f"{dest_images}/",
+                ],
+                check=True,
+            )
 
     print("Done.")
     return 0


### PR DESCRIPTION
## Summary
- `make.py` の画像rsync先に `ppsd/Images/` を追加
- 従来は `ppsd/html/Images/` のみにrsyncしていたため、`ppsd/test.html` から参照される `ppsd/Images/` に画像が配置されず表示されなかった

Closes #678

## Test plan
- [ ] CIビルド成功
- [ ] https://pwscup.github.io/pwssite/ppsd/test.html で画像が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)