### PR TITLE
GFM autolink対応: linkifyを有効化してURL自動リンク化 (#696)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.9"
 dependencies = [
     "markdown-it-py==3.0.0",
     "mdit-py-plugins==0.4.2",
+    "linkify-it-py>=2.0",
 ]
 
 [dependency-groups]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -124,7 +124,7 @@ def _build_toc_html(headings: list[tuple[int, str, str]]) -> str:
 
 
 def build_body(md_text: str) -> tuple[str, str]:
-    md = MarkdownIt("commonmark", {"html": True}).enable(["table", "strikethrough"])
+    md = MarkdownIt("commonmark", {"html": True, "linkify": True}).enable(["table", "strikethrough", "linkify"])
     footnote_plugin(md)
     tasklists_plugin(md)
 

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -65,6 +65,11 @@ class TestBuildBody:
         assert "<s>" in html or "<del>" in html
         assert "deleted text" in html
 
+    def test_autolink(self):
+        md = "Visit https://example.com for details\n"
+        _, html = build_mod.build_body(md)
+        assert '<a href="https://example.com"' in html
+
     def test_raw_html_preserved(self):
         md = "<dl>\n<dt>Key</dt>\n<dd>Value</dd>\n</dl>\n"
         _, html = build_mod.build_body(md)


### PR DESCRIPTION
## Summary
- `linkify-it-py` を依存に追加し、markdown-it-py の `linkify` オプションを有効化
- Markdown 中のURL文字列（例: `https://example.com`）が自動的に `<a>` タグに変換されるように
- autolink のユニットテストを追加

Closes #696

## 変更ファイル
- `pyproject.toml` — `linkify-it-py>=2.0` を依存追加
- `scripts/build.py` — `MarkdownIt` 初期化に `linkify: True` と `.enable(["linkify"])` を追加
- `tests/test_pandoc.py` — `test_autolink` テストケースを追加

## 備考
- `strikethrough` と `task_list` はすでに対応済みだったため、今回の変更は autolink のみ
- `test_pandoc.py`, `test_make.py` は全件パス

## Test plan
- [ ] `pytest tests/test_pandoc.py` がパスすること
- [ ] CI が通ること
- [ ] URL文字列を含む Markdown をビルドし、自動リンク化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)