### PR TITLE
ppsd: テーブルの汎用CSSスタイルを追加

### DIFF
--- a/ppsd/style.css
+++ b/ppsd/style.css
@@ -156,6 +156,19 @@ clear: left;
 #table-right td{
   text-align: right;
 }
+table{
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+}
+th, td{
+  border: 1px solid #cccccc;
+  padding: 6px 10px;
+}
+th{
+  background: #f2f2f2;
+  font-weight: bold;
+}
 em{
   font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- ppsd/style.css に汎用テーブルスタイル（table, th, td）を追加
- Markdownから生成される素の `<table>` タグにボーダー・パディング・ヘッダー背景色が適用されるようになる
- 2026/style.css と同様のルールを適用

## 背景
ppsd/style.css には `#result table` のようなID指定のセレクタしかなく、seminar.html 等の開催一覧テーブルにスタイルが効いていなかった。

## Test plan
- [ ] gh-pagesマージ後、https://pwscup.github.io/pwssite/ppsd/seminar.html の「開催一覧」テーブルにボーダー・パディングが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)